### PR TITLE
Add order management module

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -41,3 +41,25 @@ class Movement(db.Model):
     quantity = db.Column(db.Integer, nullable=False)
     note = db.Column(db.String(200))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+class Order(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    customer_name = db.Column(db.String(120), nullable=False)
+    status = db.Column(db.String(20), default='offen')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    items = db.relationship('OrderItem', backref='order', lazy=True, cascade='all, delete-orphan')
+
+    @property
+    def total_price(self):
+        return sum(item.quantity * item.unit_price for item in self.items)
+
+
+class OrderItem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    order_id = db.Column(db.Integer, db.ForeignKey('order.id'), nullable=False)
+    article_id = db.Column(db.Integer, db.ForeignKey('article.id'), nullable=False)
+    quantity = db.Column(db.Integer, nullable=False)
+    unit_price = db.Column(db.Float, nullable=False)
+
+    article = db.relationship('Article')
+

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -15,6 +15,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('main.import_csv') }}">Import</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('main.export_articles') }}">Export Artikel</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('main.export_movements') }}">Export Bewegungen</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.order_list') }}">Bestellungen</a></li>
       </ul>
       {% if enable_user_management %}
       <ul class="navbar-nav">

--- a/app/templates/order_detail.html
+++ b/app/templates/order_detail.html
@@ -1,0 +1,25 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Bestellung #{{ order.id }}</h1>
+<p>Kunde: {{ order.customer_name }}</p>
+<p>Status: {{ order.status }}</p>
+<p>Datum: {{ order.created_at }}</p>
+<table class="table table-striped">
+  <thead><tr><th>Artikel</th><th>Menge</th><th>Stückpreis</th><th>Summe</th></tr></thead>
+  <tbody>
+  {% for item in order.items %}
+  <tr>
+    <td>{{ item.article.name }}</td>
+    <td>{{ item.quantity }}</td>
+    <td>{{ '%.2f'|format(item.unit_price) }}</td>
+    <td>{{ '%.2f'|format(item.quantity * item.unit_price) }}</td>
+  </tr>
+  {% endfor %}
+  <tr>
+    <th colspan="3">Gesamt</th>
+    <th>{{ '%.2f'|format(order.total_price) }}</th>
+  </tr>
+  </tbody>
+</table>
+<a href="{{ url_for('main.edit_order', order_id=order.id) }}" class="btn btn-primary">Bearbeiten</a>
+{% endblock %}

--- a/app/templates/order_form.html
+++ b/app/templates/order_form.html
@@ -1,0 +1,31 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>{% if order %}Bestellung bearbeiten{% else %}Neue Bestellung{% endif %}</h1>
+<form method="post">
+  <div class="mb-3"><label class="form-label">Kunde</label>
+    <input class="form-control" name="customer_name" value="{{ order.customer_name if order else '' }}" required>
+  </div>
+  <div class="mb-3"><label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      {% for st in statuses %}
+      <option value="{{ st }}" {% if order and order.status==st %}selected{% endif %}>{{ st }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  {% if articles %}
+  <table class="table table-bordered">
+    <thead><tr><th>Artikel</th><th>Menge</th><th>Stückpreis</th></tr></thead>
+    <tbody>
+      {% for a in articles %}
+      <tr>
+        <td>{{ a.name }}</td>
+        <td><input type="number" name="qty_{{ a.id }}" class="form-control" value="0" min="0"></td>
+        <td><input type="number" step="0.01" name="price_{{ a.id }}" class="form-control" value="0"></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+  <button type="submit" class="btn btn-primary">Speichern</button>
+</form>
+{% endblock %}

--- a/app/templates/orders_list.html
+++ b/app/templates/orders_list.html
@@ -1,0 +1,34 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Bestellungen</h1>
+<form class="row mb-3">
+  <div class="col"><input class="form-control" type="text" name="customer" placeholder="Kunde" value="{{ request.args.get('customer','') }}"></div>
+  <div class="col"><input class="form-control" type="date" name="start" value="{{ request.args.get('start','') }}"></div>
+  <div class="col"><input class="form-control" type="date" name="end" value="{{ request.args.get('end','') }}"></div>
+  <div class="col">
+    <select name="status" class="form-select">
+      <option value="">Alle</option>
+      {% for st in statuses %}
+      <option value="{{ st }}" {% if selected_status==st %}selected{% endif %}>{{ st }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col"><button type="submit" class="btn btn-primary">Filter</button></div>
+</form>
+<a href="{{ url_for('main.new_order') }}" class="btn btn-success mb-3">Neue Bestellung</a>
+<table class="table table-striped">
+  <thead><tr><th>ID</th><th>Kunde</th><th>Status</th><th>Datum</th><th>Summe</th><th></th></tr></thead>
+  <tbody>
+  {% for o in orders %}
+  <tr>
+    <td>{{ o.id }}</td>
+    <td>{{ o.customer_name }}</td>
+    <td>{{ o.status }}</td>
+    <td>{{ o.created_at.date() }}</td>
+    <td>{{ '%.2f'|format(o.total_price) }}</td>
+    <td><a class="btn btn-sm btn-primary" href="{{ url_for('main.order_detail', order_id=o.id) }}">Details</a></td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce `Order` and `OrderItem` models with SQLAlchemy
- add CRUD routes to manage orders
- create templates for order listing, detail and form
- extend navigation with a link to orders

## Testing
- `python -m py_compile run.py app/*.py`
- `python run.py & sleep 3; pkill -f run.py`

------
https://chatgpt.com/codex/tasks/task_e_685b316d9d408325b01e3491047e214b