### PR TITLE
Add stock deduction and shipping labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dieses Projekt ist ein einfaches Lagerverwaltungssystem für Fanartikel basieren
 
 1. Abhängigkeiten installieren:
    ```bash
-   pip install flask flask_sqlalchemy flask_login werkzeug
+   pip install flask flask_sqlalchemy flask_login werkzeug fpdf
    ```
 2. Anwendung starten:
    ```bash
@@ -18,6 +18,13 @@ Die Benutzerverwaltung ist standardmäßig deaktiviert. Soll sie genutzt werden,
 kann sie über die Umgebungsvariable `ENABLE_USER_MANAGEMENT=1` aktiviert werden.
 Beim ersten Start mit aktivierter Benutzerverwaltung wird automatisch ein
 Admin-Benutzer `admin` mit Passwort `admin` angelegt.
+
+Bei Bestellungen wird der Lagerbestand der enthaltenen Artikel automatisch
+reduziert, sofern die Bestellung den Status "offen" oder "bezahlt" besitzt. Die
+Abgänge werden in den Lagerbewegungen vermerkt.
+
+Über die Detailansicht einer Bestellung kann zudem ein PDF-Versandetikett
+erstellt werden (ab Status "bezahlt").
 
 ## CSV-Import
 CSV-Dateien müssen die Spalten `name, sku, stock, category, location_primary, location_secondary` besitzen.

--- a/app/models.py
+++ b/app/models.py
@@ -40,6 +40,7 @@ class Movement(db.Model):
     article_id = db.Column(db.Integer, db.ForeignKey('article.id'), nullable=False)
     quantity = db.Column(db.Integer, nullable=False)
     note = db.Column(db.String(200))
+    order_id = db.Column(db.Integer, db.ForeignKey('order.id'))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 class Order(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -48,6 +49,7 @@ class Order(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     items = db.relationship('OrderItem', backref='order', lazy=True, cascade='all, delete-orphan')
+    movements = db.relationship('Movement', backref='order', lazy=True)
 
     @property
     def total_price(self):

--- a/app/templates/order_detail.html
+++ b/app/templates/order_detail.html
@@ -22,4 +22,7 @@
   </tbody>
 </table>
 <a href="{{ url_for('main.edit_order', order_id=order.id) }}" class="btn btn-primary">Bearbeiten</a>
+{% if order.status in ['bezahlt', 'versendet'] %}
+<a href="{{ url_for('main.order_label', order_id=order.id) }}" class="btn btn-secondary">Versandetikett erzeugen</a>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- subtract ordered quantity from stock when creating an order
- log those removals as movements
- generate PDF shipping labels for paid orders
- show button in order view for labels
- document new requirements in README

## Testing
- `python -m compileall -q app`
- `python run.py` *(fails: runs but blocked at network start? no)*

------
https://chatgpt.com/codex/tasks/task_e_685b33981fbc8325a3c0320ef460ed85