### PR TITLE
Add customer address and improve shipping label

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ reduziert, sofern die Bestellung den Status "offen" oder "bezahlt" besitzt. Die
 Abgänge werden in den Lagerbewegungen vermerkt.
 
 Über die Detailansicht einer Bestellung kann zudem ein PDF-Versandetikett
-erstellt werden (ab Status "bezahlt").
+erstellt werden (ab Status "bezahlt"). Das Etikett hat das Format 100 x 50 mm
+und enthält den standardmäßigen Absender "Fan-Kultur Xperience GmbH,\nHauptstraße 20".
 
 ## CSV-Import
 CSV-Dateien müssen die Spalten `name, sku, stock, category, location_primary, location_secondary` besitzen.

--- a/app/models.py
+++ b/app/models.py
@@ -45,6 +45,7 @@ class Movement(db.Model):
 class Order(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     customer_name = db.Column(db.String(120), nullable=False)
+    customer_address = db.Column(db.String(200))
     status = db.Column(db.String(20), default='offen')
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -246,13 +246,14 @@ def order_label(order_id):
         return redirect(url_for('main.order_detail', order_id=order.id))
     from fpdf import FPDF
 
-    pdf = FPDF()
+    pdf = FPDF(unit='mm', format=(100, 50))
     pdf.add_page()
     pdf.set_font('Arial', size=12)
-    sender = 'Fan-Kultur Xperience\nMusterstr. 1\n12345 Musterstadt'
+    sender = 'Fan-Kultur Xperience GmbH\nHauptstraße 20'
     pdf.multi_cell(0, 10, f'Absender:\n{sender}')
     pdf.ln(5)
-    pdf.multi_cell(0, 10, f'Empfänger:\n{order.customer_name}')
+    recipient = f'{order.customer_name}\n{order.customer_address or ""}'
+    pdf.multi_cell(0, 10, f'Empfänger:\n{recipient}')
     pdf.ln(5)
     pdf.cell(0, 10, f'Bestellnummer: {order.id}', ln=True)
     pdf.ln(5)
@@ -271,7 +272,9 @@ def new_order():
     statuses = ['offen', 'bezahlt', 'versendet']
     articles = Article.query.all()
     if request.method == 'POST':
-        order = Order(customer_name=request.form['customer_name'], status=request.form['status'])
+        order = Order(customer_name=request.form['customer_name'],
+                      customer_address=request.form.get('customer_address'),
+                      status=request.form['status'])
         db.session.add(order)
         db.session.flush()
         movements = []
@@ -304,6 +307,7 @@ def edit_order(order_id):
     order = Order.query.get_or_404(order_id)
     if request.method == 'POST':
         order.customer_name = request.form['customer_name']
+        order.customer_address = request.form.get('customer_address')
         order.status = request.form['status']
         db.session.commit()
         flash('Bestellung aktualisiert')

--- a/app/templates/order_detail.html
+++ b/app/templates/order_detail.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h1>Bestellung #{{ order.id }}</h1>
 <p>Kunde: {{ order.customer_name }}</p>
+<p>Adresse: {{ order.customer_address }}</p>
 <p>Status: {{ order.status }}</p>
 <p>Datum: {{ order.created_at }}</p>
 <table class="table table-striped">

--- a/app/templates/order_form.html
+++ b/app/templates/order_form.html
@@ -5,6 +5,9 @@
   <div class="mb-3"><label class="form-label">Kunde</label>
     <input class="form-control" name="customer_name" value="{{ order.customer_name if order else '' }}" required>
   </div>
+  <div class="mb-3"><label class="form-label">Adresse</label>
+    <textarea class="form-control" name="customer_address" rows="3">{{ order.customer_address if order else '' }}</textarea>
+  </div>
   <div class="mb-3"><label class="form-label">Status</label>
     <select name="status" class="form-select">
       {% for st in statuses %}


### PR DESCRIPTION
## Summary
- store address with an order
- show address in order view and form
- generate label in 100x50 mm format with new default sender
- document new label format

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685b36ca4840832594f8a4b3d8cc5816